### PR TITLE
[fix] bug fix in path_to_file_list

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,7 +2,7 @@ from typing import List
 
 def path_to_file_list(path: str) -> List[str]:
     """Reads a file and returns a list of lines in the file"""
-    li = open(path, 'w')
+    lines = open(path, 'r').read().split('\n')
     return lines
 
 def train_file_list_to_json(english_file_list: List[str], german_file_list: List[str]) -> List[str]:


### PR DESCRIPTION
### What I changed
In `path_to_file_list`, I changed the file mode from `'w'` (write) to `'r'` (read), and added `.read().split('\n')` to properly read the contents as a list of lines.

### Why it was wrong
Using `'w'` mode opens the file for writing, which clears the content and makes it impossible to read lines. Since the function is intended to read a file, `'r'` mode must be used instead.

This fix ensures that the function correctly returns a list of lines from the input file.
